### PR TITLE
Update package set link

### DIFF
--- a/src/Page/Index.purs
+++ b/src/Page/Index.purs
@@ -35,7 +35,7 @@ tryItOutSection =
                 [ code_
                     [ text
                         """upstream =
-      https://raw.githubusercontent.com/working-group-purescript-es/package-sets/main/packages.dhall
+      https://github.com/working-group-purescript-es/package-sets/releases/download/0.1.0/package-set.dhall
 """
                     ]
                 ]


### PR DESCRIPTION
Folks have been reporting CORS errors from Dhall when attempting to use the listed URL. This updates it to an alternate that appears to work better.